### PR TITLE
Clean up

### DIFF
--- a/Companion.xcodeproj/project.pbxproj
+++ b/Companion.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		A573BFF220809AAF0064A7DE /* Base.swift in Sources */ = {isa = PBXBuildFile; fileRef = A573BFF120809AAF0064A7DE /* Base.swift */; };
 		A5A328FC211007A10059F7B0 /* devURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A328FB211007A10059F7B0 /* devURLs.swift */; };
 		A5A328FE211014060059F7B0 /* errorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A328FD211014060059F7B0 /* errorResponse.swift */; };
+		A5A32901211019340059F7B0 /* UIUitls.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A32900211019340059F7B0 /* UIUitls.swift */; };
 		A5A84FF420807F7400823195 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A84FF320807F7400823195 /* AppDelegate.swift */; };
 		A5A84FF620807F7400823195 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A84FF520807F7400823195 /* ViewController.swift */; };
 		A5A84FF920807F7400823195 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A5A84FF720807F7400823195 /* Main.storyboard */; };
@@ -44,6 +45,7 @@
 		A573BFF120809AAF0064A7DE /* Base.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base.swift; sourceTree = "<group>"; };
 		A5A328FB211007A10059F7B0 /* devURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = devURLs.swift; sourceTree = "<group>"; };
 		A5A328FD211014060059F7B0 /* errorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = errorResponse.swift; sourceTree = "<group>"; };
+		A5A32900211019340059F7B0 /* UIUitls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIUitls.swift; sourceTree = "<group>"; };
 		A5A84FF020807F7400823195 /* Companion.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Companion.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5A84FF320807F7400823195 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A5A84FF520807F7400823195 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -104,6 +106,14 @@
 			path = Constants;
 			sourceTree = "<group>";
 		};
+		A5A328FF211018BF0059F7B0 /* utils */ = {
+			isa = PBXGroup;
+			children = (
+				A5A32900211019340059F7B0 /* UIUitls.swift */,
+			);
+			path = utils;
+			sourceTree = "<group>";
+		};
 		A5A84FE720807F7400823195 = {
 			isa = PBXGroup;
 			children = (
@@ -128,6 +138,7 @@
 		A5A84FF220807F7400823195 /* Companion */ = {
 			isa = PBXGroup;
 			children = (
+				A5A328FF211018BF0059F7B0 /* utils */,
 				A53A40F5210817AB00A75A4B /* Constants */,
 				A5A84FF320807F7400823195 /* AppDelegate.swift */,
 				A5A84FF520807F7400823195 /* ViewController.swift */,
@@ -298,6 +309,7 @@
 				A51D6D0320827CF4001E6FF4 /* BaseViewController.swift in Sources */,
 				A573BFF220809AAF0064A7DE /* Base.swift in Sources */,
 				A5A84FF620807F7400823195 /* ViewController.swift in Sources */,
+				A5A32901211019340059F7B0 /* UIUitls.swift in Sources */,
 				A56B5B75209190F500132FDE /* TrackingViewController.swift in Sources */,
 				A5A328FE211014060059F7B0 /* errorResponse.swift in Sources */,
 				A53A40F7210817C500A75A4B /* Constants.swift in Sources */,

--- a/Companion.xcodeproj/project.pbxproj
+++ b/Companion.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		9294B1970FF4EE0287A3CF0C /* libPods-Companion.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 093B16A8B00EA66885C44BCB /* libPods-Companion.a */; };
 		A51D6D0320827CF4001E6FF4 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A51D6D0220827CF4001E6FF4 /* BaseViewController.swift */; };
 		A53A40F7210817C500A75A4B /* Credentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53A40F6210817C500A75A4B /* Credentials.swift */; };
+		A560FE4B21115BC5005B512B /* KeychainUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A560FE4A21115BC5005B512B /* KeychainUtils.swift */; };
 		A56B5B75209190F500132FDE /* TrackingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56B5B74209190F500132FDE /* TrackingViewController.swift */; };
 		A573BFF220809AAF0064A7DE /* Base.swift in Sources */ = {isa = PBXBuildFile; fileRef = A573BFF120809AAF0064A7DE /* Base.swift */; };
 		A5A328FC211007A10059F7B0 /* devURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A328FB211007A10059F7B0 /* devURLs.swift */; };
@@ -41,6 +42,7 @@
 		6735E4DFA35FE23A8249890A /* Pods-Companion.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Companion.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Companion/Pods-Companion.debug.xcconfig"; sourceTree = "<group>"; };
 		A51D6D0220827CF4001E6FF4 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		A53A40F6210817C500A75A4B /* Credentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Credentials.swift; sourceTree = "<group>"; };
+		A560FE4A21115BC5005B512B /* KeychainUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainUtils.swift; sourceTree = "<group>"; };
 		A56B5B74209190F500132FDE /* TrackingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingViewController.swift; sourceTree = "<group>"; };
 		A573BFF120809AAF0064A7DE /* Base.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base.swift; sourceTree = "<group>"; };
 		A5A328FB211007A10059F7B0 /* devURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = devURLs.swift; sourceTree = "<group>"; };
@@ -110,6 +112,7 @@
 			isa = PBXGroup;
 			children = (
 				A5A32900211019340059F7B0 /* UIUitls.swift */,
+				A560FE4A21115BC5005B512B /* KeychainUtils.swift */,
 			);
 			path = utils;
 			sourceTree = "<group>";
@@ -310,6 +313,7 @@
 				A573BFF220809AAF0064A7DE /* Base.swift in Sources */,
 				A5A84FF620807F7400823195 /* ViewController.swift in Sources */,
 				A5A32901211019340059F7B0 /* UIUitls.swift in Sources */,
+				A560FE4B21115BC5005B512B /* KeychainUtils.swift in Sources */,
 				A56B5B75209190F500132FDE /* TrackingViewController.swift in Sources */,
 				A5A328FE211014060059F7B0 /* errorResponse.swift in Sources */,
 				A53A40F7210817C500A75A4B /* Credentials.swift in Sources */,

--- a/Companion.xcodeproj/project.pbxproj
+++ b/Companion.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		9294B1970FF4EE0287A3CF0C /* libPods-Companion.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 093B16A8B00EA66885C44BCB /* libPods-Companion.a */; };
 		A51D6D0320827CF4001E6FF4 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A51D6D0220827CF4001E6FF4 /* BaseViewController.swift */; };
-		A53A40F7210817C500A75A4B /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53A40F6210817C500A75A4B /* Constants.swift */; };
+		A53A40F7210817C500A75A4B /* Credentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53A40F6210817C500A75A4B /* Credentials.swift */; };
 		A56B5B75209190F500132FDE /* TrackingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56B5B74209190F500132FDE /* TrackingViewController.swift */; };
 		A573BFF220809AAF0064A7DE /* Base.swift in Sources */ = {isa = PBXBuildFile; fileRef = A573BFF120809AAF0064A7DE /* Base.swift */; };
 		A5A328FC211007A10059F7B0 /* devURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A328FB211007A10059F7B0 /* devURLs.swift */; };
@@ -40,7 +40,7 @@
 		093B16A8B00EA66885C44BCB /* libPods-Companion.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Companion.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6735E4DFA35FE23A8249890A /* Pods-Companion.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Companion.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Companion/Pods-Companion.debug.xcconfig"; sourceTree = "<group>"; };
 		A51D6D0220827CF4001E6FF4 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
-		A53A40F6210817C500A75A4B /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		A53A40F6210817C500A75A4B /* Credentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Credentials.swift; sourceTree = "<group>"; };
 		A56B5B74209190F500132FDE /* TrackingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingViewController.swift; sourceTree = "<group>"; };
 		A573BFF120809AAF0064A7DE /* Base.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base.swift; sourceTree = "<group>"; };
 		A5A328FB211007A10059F7B0 /* devURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = devURLs.swift; sourceTree = "<group>"; };
@@ -99,7 +99,7 @@
 		A53A40F5210817AB00A75A4B /* Constants */ = {
 			isa = PBXGroup;
 			children = (
-				A53A40F6210817C500A75A4B /* Constants.swift */,
+				A53A40F6210817C500A75A4B /* Credentials.swift */,
 				A5A328FB211007A10059F7B0 /* devURLs.swift */,
 				A5A328FD211014060059F7B0 /* errorResponse.swift */,
 			);
@@ -312,7 +312,7 @@
 				A5A32901211019340059F7B0 /* UIUitls.swift in Sources */,
 				A56B5B75209190F500132FDE /* TrackingViewController.swift in Sources */,
 				A5A328FE211014060059F7B0 /* errorResponse.swift in Sources */,
-				A53A40F7210817C500A75A4B /* Constants.swift in Sources */,
+				A53A40F7210817C500A75A4B /* Credentials.swift in Sources */,
 				A5A328FC211007A10059F7B0 /* devURLs.swift in Sources */,
 				A5A84FF420807F7400823195 /* AppDelegate.swift in Sources */,
 				A5BBBC832088561C00F9C4F7 /* UserAuthViewController.swift in Sources */,

--- a/Companion.xcodeproj/project.pbxproj
+++ b/Companion.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		A53A40F7210817C500A75A4B /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53A40F6210817C500A75A4B /* Constants.swift */; };
 		A56B5B75209190F500132FDE /* TrackingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56B5B74209190F500132FDE /* TrackingViewController.swift */; };
 		A573BFF220809AAF0064A7DE /* Base.swift in Sources */ = {isa = PBXBuildFile; fileRef = A573BFF120809AAF0064A7DE /* Base.swift */; };
+		A5A328FC211007A10059F7B0 /* devURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A328FB211007A10059F7B0 /* devURLs.swift */; };
+		A5A328FE211014060059F7B0 /* errorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A328FD211014060059F7B0 /* errorResponse.swift */; };
 		A5A84FF420807F7400823195 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A84FF320807F7400823195 /* AppDelegate.swift */; };
 		A5A84FF620807F7400823195 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A84FF520807F7400823195 /* ViewController.swift */; };
 		A5A84FF920807F7400823195 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A5A84FF720807F7400823195 /* Main.storyboard */; };
@@ -40,6 +42,8 @@
 		A53A40F6210817C500A75A4B /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		A56B5B74209190F500132FDE /* TrackingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingViewController.swift; sourceTree = "<group>"; };
 		A573BFF120809AAF0064A7DE /* Base.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base.swift; sourceTree = "<group>"; };
+		A5A328FB211007A10059F7B0 /* devURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = devURLs.swift; sourceTree = "<group>"; };
+		A5A328FD211014060059F7B0 /* errorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = errorResponse.swift; sourceTree = "<group>"; };
 		A5A84FF020807F7400823195 /* Companion.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Companion.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5A84FF320807F7400823195 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A5A84FF520807F7400823195 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -94,6 +98,8 @@
 			isa = PBXGroup;
 			children = (
 				A53A40F6210817C500A75A4B /* Constants.swift */,
+				A5A328FB211007A10059F7B0 /* devURLs.swift */,
+				A5A328FD211014060059F7B0 /* errorResponse.swift */,
 			);
 			path = Constants;
 			sourceTree = "<group>";
@@ -293,7 +299,9 @@
 				A573BFF220809AAF0064A7DE /* Base.swift in Sources */,
 				A5A84FF620807F7400823195 /* ViewController.swift in Sources */,
 				A56B5B75209190F500132FDE /* TrackingViewController.swift in Sources */,
+				A5A328FE211014060059F7B0 /* errorResponse.swift in Sources */,
 				A53A40F7210817C500A75A4B /* Constants.swift in Sources */,
+				A5A328FC211007A10059F7B0 /* devURLs.swift in Sources */,
 				A5A84FF420807F7400823195 /* AppDelegate.swift in Sources */,
 				A5BBBC832088561C00F9C4F7 /* UserAuthViewController.swift in Sources */,
 			);

--- a/Companion/Base.lproj/Main.storyboard
+++ b/Companion/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Fg5-FL-DAW">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Fg5-FL-DAW">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>

--- a/Companion/BaseViewController.swift
+++ b/Companion/BaseViewController.swift
@@ -23,7 +23,7 @@ class BaseViewController: UIViewController, UITextFieldDelegate {
     @IBOutlet weak var saveButton: UIBarButtonItem!
     @IBOutlet weak var goButton: UIButton!
     
-    var base: Base?
+    var base: Base!
     
     // Declare variables to hold address form values from Google Places
     var street_number: String = ""
@@ -43,19 +43,14 @@ class BaseViewController: UIViewController, UITextFieldDelegate {
         baseTitleTextField.layer.masksToBounds = true
         baseTitleTextField.layer.cornerRadius = 5
         
-        if let base = base {
-            baseTitleTextField.text = base.title
-            baseAddressLabel.text = base.address
-            if base.city == "" || base.state == "" {
-                baseZipCityStateLabel.text = base.zip!
-            } else {
-                baseZipCityStateLabel.text = base.zip! + " " + base.city! + ", " + base.state!
-            }
+        baseTitleTextField.text = self.base.title
+        baseAddressLabel.text = self.base.address
+        if self.base.city == "" || self.base.state == "" {
+            baseZipCityStateLabel.text = self.base.zip!
         } else {
-            baseTitleTextField.text = "Empty Base"
-            baseAddressLabel.text = ""
-            baseZipCityStateLabel.text = ""
+            baseZipCityStateLabel.text = self.base.zip! + " " + self.base.city! + ", " + self.base.state!
         }
+
         if(!(baseAddressLabel.text != nil) && (baseZipCityStateLabel.text != nil)) {
             self.goButton.isEnabled = false
         }
@@ -83,20 +78,22 @@ class BaseViewController: UIViewController, UITextFieldDelegate {
     // This method lets you configure a view controller before it's presented.
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         super.prepare(for: segue, sender: sender)
-        base?.title = baseTitleTextField.text! // saves any title changes
+        base.title = baseTitleTextField.text! // saves any title changes
         if (segue.identifier ?? "" == "track") { // Base page -> track view controller
-            if let navigationController = segue.destination as? UINavigationController {
-                if let trakcingVC = navigationController.topViewController as? TrackingViewController {
-                    trakcingVC.base = base!
-                }
+            guard let navigationController = segue.destination as? UINavigationController else {
+                fatalError("Unexpected destination: \(segue.destination)")
             }
+            guard let trakcingVC = navigationController.topViewController as? TrackingViewController else {
+                fatalError("Unexpected View Controller: \(segue.destination)")
+            }
+            trakcingVC.base = base
         }
     }
     
     //MARK: Action
     @IBAction func cancel(_ sender: UIBarButtonItem) {
         self.navigationController?.popToRootViewController(animated: true)
-        baseTitleTextField.text = base?.title
+        baseTitleTextField.text = base.title
     }
     
     @IBAction func editBase(_ sender: UIButton) {
@@ -116,21 +113,21 @@ class BaseViewController: UIViewController, UITextFieldDelegate {
 
     // Populate the address form fields.
     func fillAddressForm() {
-        base?.address = street_number + " " + route
-        base?.city = locality
-        base?.state = administrative_area_level_1
-        base?.placeID = placeID
+        base.address = street_number + " " + route
+        base.city = locality
+        base.state = administrative_area_level_1
+        base.placeID = placeID
         if postal_code_suffix != "" {
-            base?.zip = postal_code + "-" + postal_code_suffix
+            base.zip = postal_code + "-" + postal_code_suffix
         } else {
-            base?.zip = postal_code
+            base.zip = postal_code
         }
-        baseAddressLabel.text = base?.address
+        baseAddressLabel.text = base.address
         
-        if base?.city == "" || base?.state == "" {
-            baseZipCityStateLabel.text = (base?.zip)!
+        if base.city == "" || base.state == "" {
+            baseZipCityStateLabel.text = (base.zip)!
         } else {
-            baseZipCityStateLabel.text = (base?.zip)! + " " + (base?.city)! + ", " + (base?.state)! // ZIP City, State
+            baseZipCityStateLabel.text = (base.zip)! + " " + (base.city)! + ", " + (base.state)! // ZIP City, State
         }
         
         // Clear values for next time.

--- a/Companion/Constants/Credentials.swift
+++ b/Companion/Constants/Credentials.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 let google_api_key = "AIzaSyCe2zgazWR4q16Vg4P7yMcvSzTja-zmOHk"
-let st_client_id = "gk1nFtbQr4pBpJD0rzAp3vaSi555sm4s"
-let st_client_secret = "eWTSj_izMvD3nBJFXxkRDZF4aXDGKofYRZyzw_31oer31kuoY6-OVDs27nEHJu0B"
+let safetrek_client_id = "gk1nFtbQr4pBpJD0rzAp3vaSi555sm4s"
+let safetrek_client_secret = "eWTSj_izMvD3nBJFXxkRDZF4aXDGKofYRZyzw_31oer31kuoY6-OVDs27nEHJu0B"

--- a/Companion/Constants/Credentials.swift
+++ b/Companion/Constants/Credentials.swift
@@ -1,0 +1,13 @@
+//
+//  Constants.swift
+//  Companion
+//
+//  Created by David Huang on 7/24/18.
+//  Copyright © 2018 David Huang. All rights reserved.
+//
+
+import Foundation
+
+let google_api_key = "AIzaSyCe2zgazWR4q16Vg4P7yMcvSzTja-zmOHk"
+let st_client_id = "gk1nFtbQr4pBpJD0rzAp3vaSi555sm4s"
+let st_client_secret = "eWTSj_izMvD3nBJFXxkRDZF4aXDGKofYRZyzw_31oer31kuoY6-OVDs27nEHJu0B"

--- a/Companion/Constants/devURLs.swift
+++ b/Companion/Constants/devURLs.swift
@@ -11,4 +11,6 @@ import Foundation
 struct devURLs {
     var authorize = "https://account-sandbox.safetrek.io/authorize"
     var tokens = "https://login-sandbox.safetrek.io/oauth/token"
+    var alarm = "https://api-sandbox.safetrek.io/v1/alarms"
+    var refresh = "https://login-sandbox.safetrek.io/oauth/token"
 }

--- a/Companion/Constants/devURLs.swift
+++ b/Companion/Constants/devURLs.swift
@@ -7,3 +7,8 @@
 //
 
 import Foundation
+
+struct devURLs {
+    var authorize = "https://account-sandbox.safetrek.io/authorize"
+    var tokens = "https://login-sandbox.safetrek.io/oauth/token"
+}

--- a/Companion/Constants/devURLs.swift
+++ b/Companion/Constants/devURLs.swift
@@ -1,0 +1,9 @@
+//
+//  devURLs.swift
+//  Companion
+//
+//  Created by David Huang on 7/30/18.
+//  Copyright © 2018 David Huang. All rights reserved.
+//
+
+import Foundation

--- a/Companion/Constants/errorResponse.swift
+++ b/Companion/Constants/errorResponse.swift
@@ -1,0 +1,9 @@
+//
+//  errorResponse.swift
+//  Companion
+//
+//  Created by David Huang on 7/30/18.
+//  Copyright © 2018 David Huang. All rights reserved.
+//
+
+import Foundation

--- a/Companion/Constants/errorResponse.swift
+++ b/Companion/Constants/errorResponse.swift
@@ -7,3 +7,9 @@
 //
 
 import Foundation
+
+struct ErrorResponse: Decodable {
+    let code: Int
+    let message: String
+    let details: String
+}

--- a/Companion/TrackingViewController.swift
+++ b/Companion/TrackingViewController.swift
@@ -222,8 +222,8 @@ class TrackingViewController: UIViewController {
         }
         let params = [
             "grant_type": "refresh_token",
-            "client_id": st_client_id,
-            "client_secret": st_client_secret,
+            "client_id": safetrek_client_id,
+            "client_secret": safetrek_client_secret,
             "refresh_token": refresh_token
         ]
         let accessTokenRequest = try? JSONSerialization.data(withJSONObject: params, options: [])

--- a/Companion/UserAuthViewController.swift
+++ b/Companion/UserAuthViewController.swift
@@ -37,16 +37,16 @@ class UserAuthViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // for debugging purposes
-        do {
-            print("======== DELETING REFRESH TOKEN ========")
-            try Locksmith.deleteDataForUserAccount(userAccount: "user_refresh")
-            print("======== DELETING ACCESS TOKEN ========")
-            try Locksmith.deleteDataForUserAccount(userAccount: "user_access")
-            print("======== DELETING EXPIRES IN ========")
-            try Locksmith.deleteDataForUserAccount(userAccount: "user_expire")
-        } catch {
-            print("======== UNABLE TO DELETE TOKENS ========")
-        }
+//        do {
+//            print("======== DELETING REFRESH TOKEN ========")
+//            try Locksmith.deleteDataForUserAccount(userAccount: "user_refresh")
+//            print("======== DELETING ACCESS TOKEN ========")
+//            try Locksmith.deleteDataForUserAccount(userAccount: "user_access")
+//            print("======== DELETING EXPIRES IN ========")
+//            try Locksmith.deleteDataForUserAccount(userAccount: "user_expire")
+//        } catch {
+//            print("======== UNABLE TO DELETE TOKENS ========")
+//        }
     }
 
     override func didReceiveMemoryWarning() {
@@ -110,21 +110,6 @@ class UserAuthViewController: UIViewController {
  */
     
     //MARK: Private Functions
-    private func createAlert(title: String, message: String, details: String?) {
-        let formattedMessage = details != nil ? "\(message). \(details!)." : "\(message)."
-        let alert = UIAlertController(title: title, message: formattedMessage, preferredStyle: UIAlertControllerStyle.alert)
-        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { action in
-            switch action.style{
-            case .default:
-                print("default")
-            case .cancel:
-                print("cancel")
-            case .destructive:
-                print("destructive")
-            }}))
-        self.present(alert, animated: true, completion: nil)
-    }
-    
     private func getAccessToken(authorizationCode: String) {
         // STEP 3: RETRIEVING AN ACCESS TOKEN
         let url = URL(string: urls.tokens)
@@ -160,7 +145,8 @@ class UserAuthViewController: UIViewController {
                 guard let tokensjson = try? JSONDecoder().decode(ErrorResponse.self, from: data) else {
                     fatalError("Received an unexpected JSON format")
                 }
-                self.createAlert(title: "Error \(tokensjson.code)", message: tokensjson.message, details: tokensjson.details)
+                let alert = UIUtils.createAlert(title: "Error \(tokensjson.code)", message: tokensjson.message, details: tokensjson.details)
+                self.present(alert, animated: true, completion: nil)
             }
             
             do {
@@ -172,7 +158,8 @@ class UserAuthViewController: UIViewController {
                 // need to move this outside
                 self.toBases()
             } catch {
-                self.createAlert(title: "Error",message: "Could not save credentials", details: nil);
+                let alert = UIUtils.createAlert(title: "Error", message: "Could not save credentials. Try loggin in again on a different session.", details: nil)
+                self.present(alert, animated: true, completion: nil)
             }
         }
         task.resume()

--- a/Companion/UserAuthViewController.swift
+++ b/Companion/UserAuthViewController.swift
@@ -29,24 +29,24 @@ class UserAuthViewController: UIViewController {
     var refresh_token: String?
     var expires_in: Int?
     
-    // UNSAFE
-    let client_id: String = st_client_id
-    let client_secret: String = st_client_secret
+    // credentials inside Constants
+    let client_id: String = safetrek_client_id
+    let client_secret: String = safetrek_client_secret
     let redirect_uri: String = "companion://oauth"
     
     override func viewDidLoad() {
         super.viewDidLoad()
         // for debugging purposes
-//        do {
-//            print("======== DELETING REFRESH TOKEN ========")
-//            try Locksmith.deleteDataForUserAccount(userAccount: "user_refresh")
-//            print("======== DELETING ACCESS TOKEN ========")
-//            try Locksmith.deleteDataForUserAccount(userAccount: "user_access")
-//            print("======== DELETING EXPIRES IN ========")
-//            try Locksmith.deleteDataForUserAccount(userAccount: "user_expire")
-//        } catch {
-//            print("======== UNABLE TO DELETE TOKENS ========")
-//        }
+        do {
+            print("======== DELETING REFRESH TOKEN ========")
+            try Locksmith.deleteDataForUserAccount(userAccount: "user_refresh")
+            print("======== DELETING ACCESS TOKEN ========")
+            try Locksmith.deleteDataForUserAccount(userAccount: "user_access")
+            print("======== DELETING EXPIRES IN ========")
+            try Locksmith.deleteDataForUserAccount(userAccount: "user_expire")
+        } catch {
+            print("======== UNABLE TO DELETE TOKENS ========")
+        }
     }
 
     override func didReceiveMemoryWarning() {
@@ -155,14 +155,14 @@ class UserAuthViewController: UIViewController {
                 try Locksmith.saveData(data: ["access_token": self.access_token!], forUserAccount: "user_access")
                 try Locksmith.saveData(data: ["expires_in": self.expires_in!], forUserAccount: "user_expire")
                 UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "init_date")
-                // need to move this outside
-                self.toBases()
             } catch {
                 let alert = UIUtils.createAlert(title: "Error", message: "Could not save credentials. Try loggin in again on a different session.", details: nil)
                 self.present(alert, animated: true, completion: nil)
             }
+            DispatchQueue.main.async {
+                self.toBases()
+            }
         }
         task.resume()
-//        self.toBases()
     }
 }

--- a/Companion/UserAuthViewController.swift
+++ b/Companion/UserAuthViewController.swift
@@ -156,7 +156,7 @@ class UserAuthViewController: UIViewController {
                 try Locksmith.saveData(data: ["expires_in": self.expires_in!], forUserAccount: "user_expire")
                 UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "init_date")
             } catch {
-                let alert = UIUtils.createAlert(title: "Error", message: "Could not save credentials. Try loggin in again on a different session.", details: nil)
+                let alert = UIUtils.createAlert(title: "Error", message: "Could not save your credentials. Try loggin in again on a different session.", details: nil)
                 self.present(alert, animated: true, completion: nil)
             }
             DispatchQueue.main.async {

--- a/Companion/UserAuthViewController.swift
+++ b/Companion/UserAuthViewController.swift
@@ -37,16 +37,16 @@ class UserAuthViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // for debugging purposes
-        do {
-            print("======== DELETING REFRESH TOKEN ========")
-            try Locksmith.deleteDataForUserAccount(userAccount: "user_refresh")
-            print("======== DELETING ACCESS TOKEN ========")
-            try Locksmith.deleteDataForUserAccount(userAccount: "user_access")
-            print("======== DELETING EXPIRES IN ========")
-            try Locksmith.deleteDataForUserAccount(userAccount: "user_expire")
-        } catch {
-            print("======== UNABLE TO DELETE TOKENS ========")
-        }
+//        do {
+//            print("======== DELETING REFRESH TOKEN ========")
+//            try Locksmith.deleteDataForUserAccount(userAccount: "user_refresh")
+//            print("======== DELETING ACCESS TOKEN ========")
+//            try Locksmith.deleteDataForUserAccount(userAccount: "user_access")
+//            print("======== DELETING EXPIRES IN ========")
+//            try Locksmith.deleteDataForUserAccount(userAccount: "user_expire")
+//        } catch {
+//            print("======== UNABLE TO DELETE TOKENS ========")
+//        }
     }
 
     override func didReceiveMemoryWarning() {

--- a/Companion/ViewController.swift
+++ b/Companion/ViewController.swift
@@ -74,6 +74,7 @@ class ViewController: UIViewController {
         } else if (selectedBaseButton.tag == senderButtonTag.Third.rawValue) {
             index = senderButtonTag.Third.rawValue
         }
+        // The user used to be able to add Bases, but this feture is gone now
         if index < bases.count {
             baseDetailViewController.base = bases[index]
         } else {

--- a/Companion/utils/KeychainUtils.swift
+++ b/Companion/utils/KeychainUtils.swift
@@ -1,0 +1,32 @@
+//
+//  KeychainUtils.swift
+//  Companion
+//
+//  Created by David Huang on 7/31/18.
+//  Copyright © 2018 David Huang. All rights reserved.
+//
+
+import UIKit
+import Locksmith
+
+class KeychainUtils {
+    
+    static func getAccessToken()->String? {
+        let access_dict = Locksmith.loadDataForUserAccount(userAccount: "user_access")
+        guard let access_token = access_dict!["access_token"] as? String else {
+            print("UNABLE TO CONVERT ACCESS TOKEN TO STRING")
+            return nil
+        }
+        print("CONVERTED ACCESS TOKEN TO STRING")
+        return access_token
+    }
+    
+    static func getRefreshToken()->String? {
+        let refresh_dict = Locksmith.loadDataForUserAccount(userAccount: "user_refresh")
+        guard let refresh_token = refresh_dict!["refresh_token"] as? String else {
+            print("UNABLE TO CONVERT REFRESH TOKEN TO STRING")
+            return nil
+        }
+        return refresh_token
+    }
+}

--- a/Companion/utils/UIUitls.swift
+++ b/Companion/utils/UIUitls.swift
@@ -1,0 +1,9 @@
+//
+//  UIUitls.swift
+//  Companion
+//
+//  Created by David Huang on 7/31/18.
+//  Copyright © 2018 David Huang. All rights reserved.
+//
+
+import Foundation

--- a/Companion/utils/UIUitls.swift
+++ b/Companion/utils/UIUitls.swift
@@ -6,4 +6,22 @@
 //  Copyright © 2018 David Huang. All rights reserved.
 //
 
-import Foundation
+import UIKit
+
+class UIUtils {
+    
+    static func createAlert(title: String, message: String, details: String?) -> UIAlertController {
+        let formattedMessage = details != nil ? "\(message). \(details!)." : "\(message)."
+        let alert = UIAlertController(title: title, message: formattedMessage, preferredStyle: UIAlertControllerStyle.alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { action in
+            switch action.style{
+            case .default:
+                print("default")
+            case .cancel:
+                print("cancel")
+            case .destructive:
+                print("destructive")
+            }}))
+        return alert
+    }
+}


### PR DESCRIPTION
Many files have been changed here. The original aim of this branch was to clean up the code in one go, but this practice will not be sustainable in the future. 

Aiming to make commits more atomic and utilize Trello/Github workflow to manage tasks into smaller portions.

Files Added:
- Modularized repeated code. In particular, the development URLs are stored in a separate folder as constants. 
- It was also important to have an easy way to display the error response JSON to the user instead of exiting the app. So a ErrorResponse struct modeled after the error response json was added, and is used to show the user what kind of error the API ran into.
- A utils folder was added to store specific functions that are used throughout the project. Creating an alarm is used whenever an unexpected error occurs and the user should see it. So, the createAlarm method was added to the UIUtils file in order to get rid of duplicated code whenever an error arises.
- A keychainUtils file was also added to abstract interactions with Lockchain. There is a lot of similar code around the project that retrieves a certain value from Lockchain. This cleans up the repeated code.

Changes Made:
- User authentication page was cleaned up and uses the tools described above. There are more optional unwrapping handlers to ensure that debugging would be easier in the future and certain edge cases are handled better.
- ViewController (the home page) was not touched too much.
- The BaseViewController no longer takes an optional Base. It is more appropriate for the previous View to send over a Base every time; rather than allow the BaseViewController to default to an empty base if no Base is passed, it will simply load the Base's information every time. Simply put, it does not make sense for a BASEViewController to not have a Base to display.
- TrackingViewController uses the tools described above. There are more guards and if lets to catch possible errors and handle them appropriately. 