### PR TITLE
17 modularize api requests

### DIFF
--- a/Companion.xcodeproj/project.pbxproj
+++ b/Companion.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		9294B1970FF4EE0287A3CF0C /* libPods-Companion.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 093B16A8B00EA66885C44BCB /* libPods-Companion.a */; };
 		A51D6D0320827CF4001E6FF4 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A51D6D0220827CF4001E6FF4 /* BaseViewController.swift */; };
 		A53A40F7210817C500A75A4B /* Credentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53A40F6210817C500A75A4B /* Credentials.swift */; };
+		A54F042E21129D84002E9B0D /* HTTPRequestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54F042D21129D84002E9B0D /* HTTPRequestUtils.swift */; };
 		A560FE4B21115BC5005B512B /* KeychainUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A560FE4A21115BC5005B512B /* KeychainUtils.swift */; };
 		A56B5B75209190F500132FDE /* TrackingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56B5B74209190F500132FDE /* TrackingViewController.swift */; };
 		A573BFF220809AAF0064A7DE /* Base.swift in Sources */ = {isa = PBXBuildFile; fileRef = A573BFF120809AAF0064A7DE /* Base.swift */; };
@@ -42,6 +43,7 @@
 		6735E4DFA35FE23A8249890A /* Pods-Companion.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Companion.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Companion/Pods-Companion.debug.xcconfig"; sourceTree = "<group>"; };
 		A51D6D0220827CF4001E6FF4 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		A53A40F6210817C500A75A4B /* Credentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Credentials.swift; sourceTree = "<group>"; };
+		A54F042D21129D84002E9B0D /* HTTPRequestUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestUtils.swift; sourceTree = "<group>"; };
 		A560FE4A21115BC5005B512B /* KeychainUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainUtils.swift; sourceTree = "<group>"; };
 		A56B5B74209190F500132FDE /* TrackingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingViewController.swift; sourceTree = "<group>"; };
 		A573BFF120809AAF0064A7DE /* Base.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base.swift; sourceTree = "<group>"; };
@@ -113,6 +115,7 @@
 			children = (
 				A5A32900211019340059F7B0 /* UIUitls.swift */,
 				A560FE4A21115BC5005B512B /* KeychainUtils.swift */,
+				A54F042D21129D84002E9B0D /* HTTPRequestUtils.swift */,
 			);
 			path = utils;
 			sourceTree = "<group>";
@@ -320,6 +323,7 @@
 				A5A328FC211007A10059F7B0 /* devURLs.swift in Sources */,
 				A5A84FF420807F7400823195 /* AppDelegate.swift in Sources */,
 				A5BBBC832088561C00F9C4F7 /* UserAuthViewController.swift in Sources */,
+				A54F042E21129D84002E9B0D /* HTTPRequestUtils.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Companion/TrackingViewController.swift
+++ b/Companion/TrackingViewController.swift
@@ -169,7 +169,7 @@ class TrackingViewController: UIViewController {
         HTTPRequestUtils.request(requestType: "PUT", url: "\(urls.alarm)/\(self.alarm!.id)/status", body: cancelData, responseType: UpdateAlarmStatus.self, onFail: { (errorResponse) in
             self.onFail(errorResponse: errorResponse)
         }) { (updateJson) in // ON SUCCESS COMPLETION HANDLER
-            print(updateJson.status)
+            print("Alarm cancel successful, status: ",updateJson.status)
         }
     }
     
@@ -227,7 +227,7 @@ extension TrackingViewController: CLLocationManagerDelegate {
                 let expire_dictionary = Locksmith.loadDataForUserAccount(userAccount: "user_expire")
                 if let expire_in = expire_dictionary!["expires_in"] as? Double {
                     // using 0 for debugging purposes replace with expire_in when finished debugging
-                    if( time_since > 0 ) {
+                    if( time_since > expire_in ) {
                         UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "init_date")
                         getNewAccessToken() // after refreshing access token, calls createAlarm within method
                     } else {

--- a/Companion/TrackingViewController.swift
+++ b/Companion/TrackingViewController.swift
@@ -159,6 +159,7 @@ class TrackingViewController: UIViewController {
     }
     
     private func cancelAlarm() {
+        print("========== cancelAlarm ==========")
         let params = [
             "status": "CANCELED"
         ]
@@ -167,7 +168,7 @@ class TrackingViewController: UIViewController {
         }
         HTTPRequestUtils.request(requestType: "PUT", url: "\(urls.alarm)/\(self.alarm!.id)/status", body: cancelData, responseType: UpdateAlarmStatus.self, onFail: { (errorResponse) in
             self.onFail(errorResponse: errorResponse)
-        }) { (updateJson) in
+        }) { (updateJson) in // ON SUCCESS COMPLETION HANDLER
             print(updateJson.status)
         }
     }
@@ -176,7 +177,7 @@ class TrackingViewController: UIViewController {
         print("========== getNewAccessToken ==========")
         HTTPRequestUtils.refreshAccessToken(url: urls.refresh, responseType: RefreshToken.self, onFail: { (errorResponse) in
             self.onFail(errorResponse: errorResponse)
-        }) { (refreshJson) in
+        }) { (refreshJson) in // ON SUCCESS COMPLETION HANDLER
             do {
                 try Locksmith.updateData(data: ["access_token": refreshJson.access_token], forUserAccount: "user_access")
                 try Locksmith.updateData(data: ["expires_in": refreshJson.expires_in], forUserAccount: "user_expire")

--- a/Companion/utils/HTTPRequestUtils.swift
+++ b/Companion/utils/HTTPRequestUtils.swift
@@ -1,0 +1,49 @@
+//
+//  HTTPRequestUtils.swift
+//  Companion
+//
+//  Created by David Huang on 8/1/18.
+//  Copyright © 2018 David Huang. All rights reserved.
+//
+
+import UIKit
+
+class HTTPRequestUtils {
+    
+    static func request<T: Decodable>(requestType: String, url: String, body: Data, responseType: T.Type, onFail: @escaping (ErrorResponse) -> Void, completion: @escaping (T) -> Void) {
+        guard let requestURL = URL(string: url) else {
+            return
+        }
+        var request = URLRequest(url: requestURL)
+        request.httpMethod = requestType
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        guard let access_token = KeychainUtils.getAccessToken() else {
+            fatalError("Unable to get access token")
+        }
+        request.addValue("Bearer \(access_token)", forHTTPHeaderField: "Authorization")
+        
+        request.httpBody = body
+        
+        let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
+            guard error == nil else {
+                print(error!)
+                return
+            }
+            guard let data = data else {
+                print("Data is empty")
+                return
+            }
+
+            if let tokensjson = try? JSONDecoder().decode(responseType.self, from: data) {
+                completion(tokensjson)
+            } else {
+                guard let errorjson = try? JSONDecoder().decode(ErrorResponse.self, from: data) else {
+                    fatalError("Received an unexpected JSON format")
+                }
+                onFail(errorjson)
+            }
+        }
+        task.resume()
+    }
+}

--- a/Companion/utils/HTTPRequestUtils.swift
+++ b/Companion/utils/HTTPRequestUtils.swift
@@ -10,6 +10,52 @@ import UIKit
 
 class HTTPRequestUtils {
     
+    static func refreshAccessToken<T: Decodable>(url: String, responseType: T.Type, onFail: @escaping (ErrorResponse) -> Void, completion: @escaping (T) -> Void) {
+        
+        guard let refresh_token = KeychainUtils.getRefreshToken() else {
+            fatalError("Unable to get refresh token")
+        }
+        let params = [
+            "grant_type": "refresh_token",
+            "client_id": safetrek_client_id,
+            "client_secret": safetrek_client_secret,
+            "refresh_token": refresh_token
+        ]
+        guard let refreshData = try? JSONSerialization.data(withJSONObject: params, options: []) else {
+            fatalError("uh oh")
+        }
+        
+        guard let requestURL = URL(string: url) else {
+            return
+        }
+        var request = URLRequest(url: requestURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        request.httpBody = refreshData
+        
+        let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
+            guard error == nil else {
+                print(error!)
+                return
+            }
+            guard let data = data else {
+                print("Data is empty")
+                return
+            }
+            
+            if let tokensjson = try? JSONDecoder().decode(responseType.self, from: data) {
+                completion(tokensjson)
+            } else {
+                guard let errorjson = try? JSONDecoder().decode(ErrorResponse.self, from: data) else {
+                    fatalError("Received an unexpected JSON format")
+                }
+                onFail(errorjson)
+            }
+        }
+        task.resume()
+    }
+    
     static func request<T: Decodable>(requestType: String, url: String, body: Data, responseType: T.Type, onFail: @escaping (ErrorResponse) -> Void, completion: @escaping (T) -> Void) {
         guard let requestURL = URL(string: url) else {
             return


### PR DESCRIPTION
Added a new utils file for Noonlight (formerly known as SafeTrek) API calls.

The request() function makes an API call for any type of request method and request body. It uses generics so that the data JSON returned from the call is easily converted into its specific JSON (or essentially its struct). The success completion handler will have the converted JSON, and the onFail completion handler will display the error.
The refreshAccessToken() function essentially does what the request() function does, but it has more constraints. The refresh API call has a different structure from the other calls. It doesn't need an access token, the body will always be the same, and the request method will always be the same.

All the API requests in the TrackingViewController have been updated to use the two newly added functions. They pass in their respective urls, request body, desired response JSON form (struct), and two completion handlers; one for the case where the call fails, and the other for when the call succeeds.