### PR TITLE
warning if API call is unsucessful

### DIFF
--- a/Companion/Base.swift
+++ b/Companion/Base.swift
@@ -34,7 +34,7 @@ class Base: NSObject {
         self.placeID = placeID
     }
     
-    func getDuration(originLat: Double, originLong: Double, completion: @escaping (MapsResponse.Routes.Legs.Duration) -> Void) {
+    func getDuration(originLat: Double, originLong: Double, onFail: @escaping () -> Void, completion: @escaping (MapsResponse.Routes.Legs.Duration) -> Void) {
         let url: String
         if let placeID = self.placeID {
             url = "\(devURLs().directions)/json?origin=\(String(originLat)),\(String(originLong))&destination=place_id:\(placeID)&key=\(google_api_key)"
@@ -45,8 +45,9 @@ class Base: NSObject {
             }
             url = "\(devURLs().directions)/json?origin=\(String(originLat)),\(String(originLong))&destination=\(formatAddress(address: address))&key=\(google_api_key)"
         }
-        HTTPRequestUtils.directionsRequest(url: url, onFail: { (errorResponse) in
-            print("COULD NOT MAKE DIRECTIONS API CALL")
+        HTTPRequestUtils.directionsRequest(url: url, onFail: { () in
+            // completion handler within completionhandler, messy, needs to be changed
+            onFail()
         }) { (directionsJson) in
             print(directionsJson)
             if (directionsJson.status == "OK") {

--- a/Companion/TrackingViewController.swift
+++ b/Companion/TrackingViewController.swift
@@ -118,7 +118,10 @@ class TrackingViewController: UIViewController {
     
     private func startTracking() {
         // need to put guards around this, not safe
-        base?.getDuration(originLat: self.lattitude!, originLong: self.longitude!, completion: { (duration) -> Void in
+        base?.getDuration(originLat: self.lattitude!, originLong: self.longitude!, onFail: { () -> Void in
+            let alert = UIUtils.createAlert(title: "Error", message: "Could not get directions to your Base", details: nil)
+            self.present(alert, animated: true, completion: nil)
+        }, completion: { (duration) -> Void in
             let durationSec: Double = duration.value
             self.startTimer(timeInterval: 1) // for debugging purposes
         })

--- a/Companion/utils/HTTPRequestUtils.swift
+++ b/Companion/utils/HTTPRequestUtils.swift
@@ -137,7 +137,7 @@ class HTTPRequestUtils {
         task.resume()
     }
     
-    static func directionsRequest(url: String, onFail: @escaping (ErrorResponse) -> Void, completion: @escaping (MapsResponse) -> Void) {
+    static func directionsRequest(url: String, onFail: @escaping () -> Void, completion: @escaping (MapsResponse) -> Void) {
         guard let requestURL = URL(string: url) else {
             return
         }
@@ -155,10 +155,7 @@ class HTTPRequestUtils {
             if let tokensjson = try? JSONDecoder().decode(MapsResponse.self, from: data) {
                 completion(tokensjson)
             } else {
-                guard let errorjson = try? JSONDecoder().decode(ErrorResponse.self, from: data) else {
-                    fatalError("Received an unexpected JSON format")
-                }
-                onFail(errorjson)
+                onFail()
             }
         }
         task.resume()


### PR DESCRIPTION
Added a onFail completion handler to the Base class' getDuration() function, and also to the HttpUtils function for Google Directions API calls. This completion handler will display a warning that informs the user that the app could not get directions to their Base.